### PR TITLE
Adds three safehouses

### DIFF
--- a/_maps/safehouses/den.dmm
+++ b/_maps/safehouses/den.dmm
@@ -1,0 +1,35 @@
+"a" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 5},/turf/open/floor/pod/light,/area/station/virtual_domain/safehouse/exit)
+"c" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/dim/directional/east,/turf/open/floor/eighties,/area/station/virtual_domain/safehouse/send)
+"e" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 8},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"f" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"g" = (/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"i" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/dim/directional/west,/obj/structure/sign/departments/cargo/directional/west,/turf/open/floor/pod,/area/station/virtual_domain/safehouse)
+"n" = (/turf/open/floor/pod,/area/station/virtual_domain/safehouse)
+"p" = (/obj/structure/railing,/obj/effect/turf_decal/siding/dark{dir = 10},/turf/open/floor/eighties,/area/station/virtual_domain/safehouse/send)
+"q" = (/obj/structure/table/reinforced/plastitaniumglass,/obj/effect/spawner/random/food_or_drink/snack{pixel_x = 4; pixel_y = 2},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"t" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 8},/obj/effect/decal/cleanable/generic,/turf/open/floor/pod/light,/area/station/virtual_domain/safehouse/exit)
+"u" = (/obj/machinery/light/small/dim/directional/south,/obj/effect/spawner/random/vending/colavend,/turf/open/floor/pod,/area/station/virtual_domain/safehouse)
+"w" = (/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"x" = (/turf/closed/wall,/area/template_noop)
+"y" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters/preopen{dir = 4; id = safehouseshutter},/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"A" = (/obj/effect/turf_decal/siding/dark{dir = 8},/turf/open/floor/eighties,/area/station/virtual_domain/safehouse/send)
+"D" = (/obj/effect/turf_decal/trimline/yellow/corner{dir = 4},/turf/open/floor/pod/light,/area/station/virtual_domain/safehouse/exit)
+"F" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 9},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"G" = (/obj/structure/railing,/obj/effect/turf_decal/siding/dark,/obj/structure/sign/poster/contraband/hacking_guide/directional/east,/turf/open/floor/eighties,/area/station/virtual_domain/safehouse/send)
+"K" = (/turf/closed/wall,/area/station/virtual_domain/safehouse)
+"M" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters/preopen{dir = 1; id = safehouseshutter},/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"R" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters/preopen{id = safehouseshutter},/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"S" = (/obj/structure/chair/office{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/dim/directional/south,/turf/open/floor/pod,/area/station/virtual_domain/safehouse)
+"U" = (/obj/structure/table/reinforced/plastitaniumglass,/obj/machinery/button/door{pixel_x = 4; pixel_y = 4; id = safehouseshutter},/obj/effect/spawner/random/food_or_drink/refreshing_beverage{pixel_y = 6; pixel_x = -10},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"W" = (/obj/effect/turf_decal/trimline/yellow/line{dir = 4},/turf/open/floor/pod/dark,/area/station/virtual_domain/safehouse)
+"X" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters/preopen{dir = 8; id = safehouseshutter},/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"Y" = (/obj/effect/decal/cleanable/generic,/obj/effect/turf_decal/trimline/yellow/warning{dir = 4},/obj/effect/turf_decal/trimline/yellow/corner{dir = 1},/turf/open/floor/pod,/area/station/virtual_domain/safehouse)
+
+(1,1,1) = {"
+KRKfKRK
+KiFYAcK
+KnewpGK
+ygeWqUX
+yutDaSX
+xKMMMKK
+"}

--- a/_maps/safehouses/dig.dmm
+++ b/_maps/safehouses/dig.dmm
@@ -1,0 +1,27 @@
+"a" = (/obj/structure/railing{dir = 4},/obj/effect/turf_decal/loading_area,/obj/effect/turf_decal/box/corners,/obj/effect/turf_decal/sand/plating,/turf/open/floor/plating,/area/station/virtual_domain/safehouse/send)
+"e" = (/obj/effect/turf_decal/loading_area,/obj/effect/turf_decal/box/corners{dir = 8},/obj/effect/turf_decal/sand/plating,/turf/open/floor/plating,/area/station/virtual_domain/safehouse/send)
+"h" = (/obj/effect/turf_decal/sand/plating,/obj/effect/turf_decal/sand/plating,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"k" = (/obj/effect/turf_decal/siding/yellow/corner{dir = 8},/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"n" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"p" = (/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"t" = (/obj/structure/table,/obj/item/coin/gold{pixel_x = -6; pixel_y = 2},/obj/item/flashlight/lantern{pixel_y = 8; pixel_x = 4; on = 1},/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"u" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/turf_decal/siding/yellow,/obj/effect/decal/cleanable/oil/streak,/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"v" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/decal/remains/xeno/larva,/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"x" = (/turf/closed/mineral/asteroid,/area/template_noop)
+"z" = (/obj/effect/turf_decal/sand/plating,/obj/machinery/door/airlock/maintenance/glass,/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"B" = (/turf/closed/mineral/asteroid,/area/station/virtual_domain/safehouse)
+"E" = (/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse/exit)
+"K" = (/turf/closed/wall/rock,/area/station/virtual_domain/safehouse)
+"M" = (/obj/effect/turf_decal/sand/plating,/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+"S" = (/obj/effect/turf_decal/siding/yellow{dir = 8},/obj/effect/decal/cleanable/dirt/dust,/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"U" = (/obj/effect/turf_decal/siding/yellow,/obj/structure/railing/corner,/obj/effect/decal/remains/xeno,/turf/open/misc/asteroid,/area/station/virtual_domain/safehouse)
+"Z" = (/obj/effect/turf_decal/sand/plating,/obj/effect/turf_decal/siding/yellow/corner,/obj/effect/turf_decal/sand/plating,/obj/item/flashlight/glowstick{on = 1},/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+
+(1,1,1) = {"
+BKKzKKB
+BhvptKK
+KMnppEB
+KZuUkEB
+BBeaSEK
+xKKKBKK
+"}

--- a/_maps/safehouses/shuttle.dmm
+++ b/_maps/safehouses/shuttle.dmm
@@ -1,0 +1,32 @@
+"a" = (/obj/effect/turf_decal/tile/neutral/half/contrasted{dir = 1},/obj/effect/turf_decal/stripes/line,/turf/open/floor/iron,/area/station/virtual_domain/safehouse/exit)
+"f" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/computer{dir = 8; name = "shuttle console"; icon_screen = "shuttle"},/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"i" = (/obj/effect/turf_decal/delivery,/obj/machinery/light/small/directional/south,/turf/open/floor/iron,/area/station/virtual_domain/safehouse/send)
+"j" = (/obj/machinery/power/shuttle_engine/propulsion/burst{dir = 8},/obj/structure/window/reinforced/spawner/directional/east,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plating/airless,/area/station/virtual_domain/safehouse)
+"l" = (/obj/effect/turf_decal/delivery,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse/send)
+"n" = (/obj/effect/turf_decal/tile/neutral{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 6},/obj/machinery/light/small/directional/south,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse/exit)
+"o" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/obj/effect/turf_decal/stripes/line{dir = 6},/obj/structure/table/reinforced,/obj/item/tank/internals/emergency_oxygen{pixel_x = 3},/obj/item/clothing/mask/gas,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"p" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/obj/structure/chair/comfy/shuttle{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"r" = (/obj/effect/turf_decal/tile/neutral,/obj/effect/turf_decal/stripes/line{dir = 5},/obj/structure/table/reinforced,/obj/effect/decal/cleanable/dirt,/obj/item/storage/toolbox/emergency,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"x" = (/turf/closed/wall/mineral/titanium,/area/template_noop)
+"A" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"B" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/blood/old,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"D" = (/obj/effect/turf_decal/stripes/end,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"E" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/door/airlock/shuttle/glass,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/sand/volcanic,/turf/open/floor/iron/white,/area/station/virtual_domain/safehouse)
+"F" = (/obj/effect/turf_decal/tile/neutral/half/contrasted,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/small/directional/north,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"G" = (/obj/effect/turf_decal/tile/neutral/half/contrasted,/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/small/directional/north,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"I" = (/obj/effect/turf_decal/stripes/end{dir = 1},/obj/effect/turf_decal/sand/volcanic,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"K" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/obj/effect/turf_decal/stripes/line,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"L" = (/obj/effect/turf_decal/stripes/line{dir = 10},/obj/effect/decal/cleanable/generic,/turf/open/floor/iron,/area/station/virtual_domain/safehouse/exit)
+"Q" = (/obj/effect/turf_decal/tile/neutral/fourcorners,/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"S" = (/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/iron,/area/station/virtual_domain/safehouse)
+"V" = (/turf/closed/wall/mineral/titanium,/area/station/virtual_domain/safehouse)
+"W" = (/obj/effect/spawner/structure/window/reinforced/shuttle,/turf/open/floor/plating,/area/station/virtual_domain/safehouse)
+
+(1,1,1) = {"
+VWVEVWV
+jIGSFrV
+WAQQpfW
+WDBKKoW
+jilLanV
+xVWVWVV
+"}

--- a/code/modules/bitmining/virtual_domain/safehouses.dm
+++ b/code/modules/bitmining/virtual_domain/safehouses.dm
@@ -17,6 +17,12 @@
 /// The default safehouse map template.
 /datum/map_template/safehouse/wood
 
+/datum/map_template/safehouse/den
+	filename = "den.dmm"
+
+/datum/map_template/safehouse/dig
+	filename = "dig.dmm"
+
 /**
  * Your safehouse here
  * /datum/map_template/safehouse/your_type

--- a/code/modules/bitmining/virtual_domain/safehouses.dm
+++ b/code/modules/bitmining/virtual_domain/safehouses.dm
@@ -23,6 +23,9 @@
 /datum/map_template/safehouse/dig
 	filename = "dig.dmm"
 
+/datum/map_template/safehouse/shuttle
+	filename = "shuttle.dmm"
+
 /**
  * Your safehouse here
  * /datum/map_template/safehouse/your_type


### PR DESCRIPTION
Adds two safehouses;
"den.dmm" | uses a similar layout to the default safehouse, but themed for the bitminers
"dig.dmm" | uses a different layout with an asteroid theme, has only 2 tiles for loot
"shuttle.dmm" | different layout themed as a mining shuttle, has 2 tiles for loot